### PR TITLE
use imports map for self imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Naming convention
 
-Wrap uses of `JSX` component, with a valid [custom element](https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name) tag, composed of the `jspm-packages-{exports[subpath] || importmap.imports[subpath]}`.
+Wrap uses of `JSX` component, with a valid [custom element](https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name) tag, composed of the `jspm-packages-{imports[subpath] || importmap.imports[subpath]}`.
 
 Intention is to be compatible with API of compiling and using JSX Components to custom-elements
 https://nanojsx.io/docs.html#:~:text=root%27))-,CustomElementsMode,-You%20can%20easily
@@ -14,8 +14,8 @@ https://nanojsx.io/docs.html#:~:text=root%27))-,CustomElementsMode,-You%20can%20
 ```jsx
 
     import { Fragment, h } from "nano-jsx";
-    import { Header } from "@jspm/packages/header";
-    import { Hero } from "@jspm/packages/hero";
+    import { Header } from "#header";
+    import { Hero } from "#hero";
 
     function Home() {
         return (
@@ -40,7 +40,7 @@ https://nanojsx.io/docs.html#:~:text=root%27))-,CustomElementsMode,-You%20can%20
         render(<Home />
     </jspm-packages>
 ```
-i.e. `@jspm/packages/header` -> `jspm-packages-header`
+i.e. `@jspm/packages/header` || `#header` -> `jspm-packages-header`
 # credit
 
 <a href="https://www.flaticon.com/free-icons/external-link" title="external link icons">External link icons created by Moon.de - Flaticon</a>

--- a/package.json
+++ b/package.json
@@ -1,187 +1,128 @@
 {
   "name": "@jspm/packages",
   "devDependencies": {
-    "@jspm/generator": "^1.0.0-beta.36",
+    "@jspm/generator": "^1.0.0-beta.37",
     "@jspm/plugin-rollup": "github:jspm/rollup-plugin-jspm",
+    "@rollup/plugin-replace": "^4.0.0",
     "@swc/cli": "^0.1.57",
-    "@swc/core": "^1.2.241",
+    "@swc/core": "^1.3.1",
     "mkdirp": "^1.0.4",
-    "rollup": "^2.78.1",
-    "typescript": "^4.7.4"
+    "rollup": "^2.79.0",
+    "typescript": "^4.8.3"
+  },
+  "scripts": {
+    "build": "rollup -c"
+  },
+  "imports": {
+    "#constants": {
+      "browser": "./lib/constants.js",
+      "default": "./src/constants.ts"
+    },
+    "#featured-packages-list": {
+      "browser": "./lib/featured-packages-list.js",
+      "default": "./src/featured-packages-list.ts"
+    },
+    "#functions": {
+      "browser": "./lib/functions.js",
+      "default": "./src/functions.ts"
+    },
+    "#generator-link": {
+      "browser": "./lib/generator-link.js",
+      "default": "./src/generator-link.tsx"
+    },
+    "#header": {
+      "browser": "./lib/header.js",
+      "default": "./src/header.tsx"
+    },
+    "#hero": {
+      "browser": "./lib/hero.js",
+      "default": "./src/hero.tsx"
+    },
+    "#home": {
+      "browser": "./lib/home.js",
+      "default": "./src/home.tsx"
+    },
+    "#home-ssr": {
+      "browser": "./lib/home-ssr.js",
+      "default": "./src/home-ssr.tsx"
+    },
+    "#importmap-dialog": {
+      "browser": "./lib/importmap-dialog.js",
+      "default": "./src/importmap-dialog.tsx"
+    },
+    "#importmap-toggle-button": {
+      "browser": "./lib/importmap-toggle-button.js",
+      "default": "./src/importmap-toggle-button.tsx"
+    },
+    "#logo": {
+      "browser": "./lib/logo.js",
+      "default": "./src/logo.tsx"
+    },
+    "#nav": {
+      "browser": "./lib/nav.js",
+      "default": "./src/nav.tsx"
+    },
+    "#package": "./src/package.tsx",
+    "#package.json": "./package.json",
+    "#package-exports": {
+      "browser": "./lib/package-exports.js",
+      "default": "./src/package-exports.tsx"
+    },
+    "#package-export-add-to-importmap-toggle": {
+      "browser": "./lib/package-export-add-to-importmap-toggle.js",
+      "default": "./src/package-export-add-to-importmap-toggle.tsx"
+    },
+    "#package-quality-check": "./src/package-quality-check.ts",
+    "#package-ssr": "./src/package-ssr.tsx",
+    "#readme": {
+      "browser": "./lib/readme.js",
+      "default": "./src/readme.tsx"
+    },
+    "#renderer": {
+      "browser": "./lib/renderer.js",
+      "default": "./src/renderer.ts"
+    },
+    "#repository-url": "./src/repository-url.js",
+    "#search": {
+      "browser": "./lib/search.js",
+      "default": "./src/search.tsx"
+    },
+    "#search-result": {
+      "browser": "./lib/search-result.js",
+      "default": "./src/search-result.tsx"
+    },
+    "#search-results": {
+      "browser": "./lib/search-results.js",
+      "default": "./src/search-results.tsx"
+    },
+    "#search-results-ssr": "./src/search-results-ssr.tsx",
+    "#statehash": {
+      "browser": "./lib/statehash.js",
+      "default": "./src/statehash.ts"
+    },
+    "#store": {
+      "browser": "./lib/store.js",
+      "default": "./src/store.ts"
+    },
+    "#score": {
+      "browser": "./lib/score.js",
+      "default": "./src/score.tsx"
+    },
+    "#types": "./types.ts",
+    "#static-resources": "./lib/static-resources.json"
   },
   "exports": {
     ".": {
       "default": "./src/request-handlers.tsx"
     },
-    "./aside": {
-      "browser": "./lib/aside.js",
-      "default": "./src/aside.tsx"
-    },
-    "./constants": {
-      "browser": "./lib/constants.js",
-      "default": "./src/constants.ts"
-    },
     "./dom": {
       "browser": "./lib/home-dom.js"
-    },
-    "./dom-main": {
-      "browser": "./lib/dom-main.js"
-    },
-    "./exports": {
-      "browser": "./lib/exports.js",
-      "default": "./src/exports.tsx"
-    },
-    "./featured-packages": {
-      "browser": "./lib/featured-packages.js",
-      "default": "./src/featured-packages.tsx"
-    },
-    "./featured-packages-list": {
-      "browser": "./lib/featured-packages-list.js",
-      "default": "./src/featured-packages-list.ts"
-    },
-    "./footer": {
-      "browser": "./lib/footer.js",
-      "default": "./src/footer.tsx"
-    },
-    "./functions": {
-      "browser": "./lib/functions.js",
-      "default": "./src/functions.ts"
-    },
-    "./generate-statehash": {
-      "browser": "./lib/generate-statehash.js",
-      "default": "./src/generate-statehash.ts"
-    },
-    "./generator-link": {
-      "browser": "./lib/generator-link.js",
-      "default": "./src/generator-link.tsx"
-    },
-    "./header": {
-      "browser": "./lib/header.js",
-      "default": "./src/header.tsx"
-    },
-    "./hero": {
-      "browser": "./lib/hero.js",
-      "default": "./src/hero.tsx"
-    },
-    "./home": {
-      "browser": "./lib/home.js",
-      "default": "./src/home.tsx"
-    },
-    "./home-ssr": {
-      "browser": "./lib/home-ssr.js",
-      "default": "./src/home-ssr.tsx"
-    },
-    "./importmap-dialog": {
-      "browser": "./lib/importmap-dialog.js",
-      "default": "./src/importmap-dialog.tsx"
-    },
-    "./importmap-toggle-button": {
-      "browser": "./lib/importmap-toggle-button.js",
-      "default": "./src/importmap-toggle-button.tsx"
-    },
-    "./jspm-package-exports": {
-      "browser": "./lib/jspm-package-exports.js",
-      "default": "./src/jspm-package-exports.tsx"
-    },
-    "./logo": {
-      "browser": "./lib/logo.js",
-      "default": "./src/logo.tsx"
-    },
-    "./nav": {
-      "browser": "./lib/nav.js",
-      "default": "./src/nav.tsx"
-    },
-    "./package": {
-      "browser": "./lib/package.js",
-      "default": "./src/package.tsx"
-    },
-    "./package.json": {
-      "browser": "./package.json",
-      "default": "./package.json"
     },
     "./package-dom": {
       "browser": "./lib/package-dom.js"
     },
-    "./package-dom-root": {
-      "browser": "./lib/package-dom-root.js"
-    },
-    "./package-exports": {
-      "browser": "./lib/package-exports.js",
-      "default": "./src/package-exports.tsx"
-    },
-    "./package-export-add-to-importmap-toggle": {
-      "browser": "./lib/package-export-add-to-importmap-toggle.js",
-      "default": "./src/package-export-add-to-importmap-toggle.tsx"
-    },
-    "./package-quality-check": {
-      "browser": "./lib/package-quality-check.js",
-      "default": "./src/package-quality-check.ts"
-    },
-    "./package-ssr": {
-      "default": "./src/package-ssr.tsx"
-    },
-    "./readme": {
-      "browser": "./lib/readme.js",
-      "default": "./src/readme.tsx"
-    },
-    "./renderer": {
-      "browser": "./lib/renderer.js",
-      "default": "./src/renderer.ts"
-    },
-    "./repository-url": {
-      "default": "./src/repository-url.js"
-    },
-    "./search": {
-      "browser": "./lib/search.js",
-      "default": "./src/search.tsx"
-    },
     "./search-dom": {
       "browser": "./lib/search-dom.js"
-    },
-    "./search-result": {
-      "browser": "./lib/search-result.js",
-      "default": "./src/search-result.tsx"
-    },
-    "./search-results": {
-      "browser": "./lib/search-results.js",
-      "default": "./src/search-results.tsx"
-    },
-    "./search-results-ssr": {
-      "default": "./src/search-results-ssr.tsx"
-    },
-    "./separator": {
-      "browser": "./lib/separator.js",
-      "default": "./src/separator.tsx"
-    },
-    "./ssr-root": {
-      "browser": "./lib/ssr-root.js",
-      "default": "./src/ssr-root.tsx"
-    },
-    "./state": {
-      "browser": "./lib/state.js",
-      "default": "./src/state.ts"
-    },
-    "./statehash": {
-      "browser": "./lib/statehash.js",
-      "default": "./src/statehash.ts"
-    },
-    "./static-resources": {
-      "default": "./lib/static-resources.json"
-    },
-    "./store": {
-      "browser": "./lib/store.js",
-      "default": "./src/store.ts"
-    },
-    "./score": {
-      "browser": "./lib/score.js",
-      "default": "./src/score.tsx"
-    },
-    "./types": {
-      "default": "./types.ts"
-    },
-    "./utils": {
-      "browser": "./lib/utils.js",
-      "default": "./utils.ts"
     }
   },
   "type": "module"

--- a/server.tsx
+++ b/server.tsx
@@ -1,4 +1,4 @@
-import { serve } from "https://deno.land/std@0.152.0/http/server.ts";
+import { serve } from "https://deno.land/std@0.156.0/http/server.ts";
 import { requestHandler } from "@jspm/packages";
 
 if (import.meta?.main) {

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -1,4 +1,4 @@
-import type { PackageDescriptor } from "@jspm/packages/types";
+import type { PackageDescriptor } from "#types";
 
 function fromPkgStr(pkg: string) {
   const versionIndex = pkg.indexOf("@", 1);

--- a/src/generate-statehash.ts
+++ b/src/generate-statehash.ts
@@ -1,15 +1,20 @@
-import { createContext } from 'nano-jsx'
+import { createContext } from "nano-jsx";
 
-const JSPMGeneratorContext = createContext('');
+const JSPMGeneratorContext = createContext("");
 
-async function getStateHash({ name, version, subpath, exports, selectedDeps, jspmGeneratorState }) {
-  const { stateToHash } = await import(
-    "@jspm/packages/statehash"
-  );
+async function getStateHash({
+  name,
+  version,
+  subpath,
+  exports,
+  selectedDeps,
+  jspmGeneratorState,
+}) {
+  const { stateToHash } = await import("#statehash");
 
   let deps = [];
-  
-  if(selectedDeps){
+
+  if (selectedDeps) {
     deps = selectedDeps;
   } else if (exports && exports.length > 0) {
     deps = exports.map((subpath) => {
@@ -43,7 +48,7 @@ async function getStateHash({ name, version, subpath, exports, selectedDeps, jsp
   };
 
   const stateHash = await stateToHash(state);
-  JSPMGeneratorContext.set(stateHash)
+  JSPMGeneratorContext.set(stateHash);
   return stateHash;
 }
 

--- a/src/header.tsx
+++ b/src/header.tsx
@@ -1,8 +1,8 @@
 /** @jsx h */
 import { h } from "nano-jsx";
-import { Logo } from "@jspm/packages/logo";
-import { Search } from "@jspm/packages/search";
-import { Nav } from "@jspm/packages/nav";
+import { Logo } from "#logo";
+import { Search } from "#search";
+import { Nav } from "#nav";
 
 type Prop = {
   search?: boolean;

--- a/src/hero.tsx
+++ b/src/hero.tsx
@@ -1,6 +1,6 @@
 /** @jsx h */
 import { Fragment, h } from "nano-jsx";
-import { Score } from "@jspm/packages/score";
+import { Score } from "#score";
 
 function GithubIcon() {
   return (

--- a/src/home-dom.tsx
+++ b/src/home-dom.tsx
@@ -4,15 +4,15 @@
 /// <reference types="https://deno.land/x/nano_jsx@v0.0.33/types.d.ts" />
 
 import { h, hydrate, Component } from "nano-jsx";
-import { store } from "@jspm/packages/store";
-import type { ENV, Store } from "@jspm/packages/store";
-import { fromPkgStrToPin, sortArray } from "@jspm/packages/functions";
-import { ImportmapToggleButton } from "@jspm/packages/importmap-toggle-button";
-import type { ImportmapToggleButtonProp } from "@jspm/packages/importmap-toggle-button";
-import { ImportMapDialog } from "@jspm/packages/importmap-dialog";
-import type { ImportMapDialogProp } from "@jspm/packages/importmap-dialog";
-import { GeneratorLink } from "@jspm/packages/generator-link";
-import type { GeneratorLinkProp } from "@jspm/packages/generator-link";
+import { store } from "#store";
+import type { ENV, Store } from "#store";
+import { fromPkgStrToPin, sortArray } from "#functions";
+import { ImportmapToggleButton } from "#importmap-toggle-button";
+import type { ImportmapToggleButtonProp } from "#importmap-toggle-button";
+import { ImportMapDialog } from "#importmap-dialog";
+import type { ImportMapDialogProp } from "#importmap-dialog";
+import { GeneratorLink } from "#generator-link";
+import type { GeneratorLinkProp } from "#generator-link";
 import { Generator } from "@jspm/generator";
 
 function hydrateImportmapToggleButton({
@@ -159,7 +159,7 @@ class DOM extends Component {
   };
 
   generateJSPMGeneratorHash = async (state) => {
-    const { stateToHash } = await import("@jspm/packages/statehash");
+    const { stateToHash } = await import("#statehash");
     const generatorHash = await stateToHash(state);
 
     this.store.setState({

--- a/src/home-ssr.tsx
+++ b/src/home-ssr.tsx
@@ -1,7 +1,7 @@
 /** @jsx h */
 
 import { h } from "nano-jsx";
-import { Home } from "@jspm/packages/home";
+import { Home } from "#home";
 
 function HomeSSR() {
   return (

--- a/src/home.html
+++ b/src/home.html
@@ -8,7 +8,7 @@
   <link rel="shortcut icon" href="/favicon.ico">
   <link rel="stylesheet" href="https://ga.jspm.io/npm:normalize.css@8.0.1/normalize.css" />
   <link rel="stylesheet"
-    href="https://fonts.googleapis.com/css2?family=Abril+Fatface&family=Sen:wght@400;700;800&family=Roboto+Condensed:wght@300&family=DM+Mono&family=Bebas+Neue&family=Major+Mono+Display&family=Playfair+Display:ital,wght@0,400;0,700;0,900;1,700&family=Source+Code+Pro&family=Source+Sans+Pro:wght@700&&family=Vollkorn&family=Inter:wght@200;400;800&display=swap" />
+    href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;700&family=Abril+Fatface&family=Sen:wght@400;700;800&family=Roboto+Condensed:wght@300&family=DM+Mono&family=Bebas+Neue&family=Major+Mono+Display&family=Playfair+Display:ital,wght@0,400;0,700;0,900;1,700&family=Source+Code+Pro&family=Source+Sans+Pro:wght@700&&family=Vollkorn&family=Inter:wght@200;400;800&display=swap" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/PrismJS/prism-themes@master/themes/prism-gruvbox-dark.css">
   <link rel="stylesheet" href="/custom-properties.css" />
   <link rel="stylesheet" href="/style.css" />

--- a/src/home.tsx
+++ b/src/home.tsx
@@ -1,7 +1,7 @@
 /** @jsx h */
 import { Fragment, h } from "nano-jsx";
-import { Header } from "@jspm/packages/header";
-import { Search } from "@jspm/packages/search";
+import { Header } from "#header";
+import { Search } from "#search";
 
 function Home() {
   return (

--- a/src/importmap-dialog.tsx
+++ b/src/importmap-dialog.tsx
@@ -7,7 +7,7 @@ import {
   fromPkgStr,
   sortArray,
   copyToClipboard,
-} from "@jspm/packages/functions";
+} from "#functions";
 
 type Prop = {
   generatorHash: string;

--- a/src/nav.tsx
+++ b/src/nav.tsx
@@ -1,7 +1,7 @@
 /** @jsx h */
 import { h } from "nano-jsx";
-import { ImportmapToggleButton } from "@jspm/packages/importmap-toggle-button";
-import { GeneratorLink } from "@jspm/packages/generator-link";
+import { ImportmapToggleButton } from "#importmap-toggle-button";
+import { GeneratorLink } from "#generator-link";
 
 function Nav() {
   return (

--- a/src/package-dom.tsx
+++ b/src/package-dom.tsx
@@ -4,17 +4,17 @@
 /// <reference types="https://deno.land/x/nano_jsx@v0.0.33/types.d.ts" />
 
 import { h, hydrate, Component } from "nano-jsx";
-import { store } from "@jspm/packages/store";
-import type { ENV, Store } from "@jspm/packages/store";
-import { fromPkgStrToPin, toPkgStr, sortArray } from "@jspm/packages/functions";
-import { ImportmapToggleButton } from "@jspm/packages/importmap-toggle-button";
-import type { ImportmapToggleButtonProp } from "@jspm/packages/importmap-toggle-button";
-import { ImportMapDialog } from "@jspm/packages/importmap-dialog";
-import type { ImportMapDialogProp } from "@jspm/packages/importmap-dialog";
-import { PackageExportAddToImportmapToggle } from "@jspm/packages/package-export-add-to-importmap-toggle";
-import type { PackageExportAddToImportmapToggleProp } from "@jspm/packages/package-export-add-to-importmap-toggle";
-import { GeneratorLink } from "@jspm/packages/generator-link";
-import type { GeneratorLinkProp } from "@jspm/packages/generator-link";
+import { store } from "#store";
+import type { ENV, Store } from "#store";
+import { fromPkgStrToPin, toPkgStr, sortArray } from "#functions";
+import { ImportmapToggleButton } from "#importmap-toggle-button";
+import type { ImportmapToggleButtonProp } from "#importmap-toggle-button";
+import { ImportMapDialog } from "#importmap-dialog";
+import type { ImportMapDialogProp } from "#importmap-dialog";
+import { PackageExportAddToImportmapToggle } from "#package-export-add-to-importmap-toggle";
+import type { PackageExportAddToImportmapToggleProp } from "#package-export-add-to-importmap-toggle";
+import { GeneratorLink } from "#generator-link";
+import type { GeneratorLinkProp } from "#generator-link";
 import { Generator } from "@jspm/generator";
 
 function hydrateImportmapToggleButton({
@@ -129,7 +129,7 @@ function generateSandboxURLs() {
         { esModuleShims: true }
       );
 
-      const { getSandboxHash } = await import("@jspm/packages/statehash");
+      const { getSandboxHash } = await import("#statehash");
       const hash = await getSandboxHash(outHtml);
       const sandboxURL = `https://jspm.org/sandbox${hash}`;
       const sandboxLink = document.createElement("a");
@@ -242,7 +242,7 @@ class DOM extends Component {
   };
 
   generateJSPMGeneratorHash = async (state) => {
-    const { stateToHash } = await import("@jspm/packages/statehash");
+    const { stateToHash } = await import("#statehash");
     const generatorHash = await stateToHash(state);
 
     this.store.setState({

--- a/src/package-quality-check.ts
+++ b/src/package-quality-check.ts
@@ -1,5 +1,5 @@
 
-import hostedGitInfo from "@jspm/packages/repository-url";
+import hostedGitInfo from "#repository-url";
 
 // 🙏🏻🙏🏻🙏🏻 Gratefully taken from
 // - https://github.com/skypackjs/package-check/blob/ee925e7410bdd8252c0582b54f841231a4ae9bbf/src/index.ts

--- a/src/package-ssr.tsx
+++ b/src/package-ssr.tsx
@@ -1,8 +1,8 @@
 /** @jsx h */
 
 import { h } from "nano-jsx";
-import { Package } from "@jspm/packages/package";
-import type { Maintainer, ExportsTarget } from "@jspm/packages/types";
+import { Package } from "#package";
+import type { Maintainer, ExportsTarget } from "#types";
 
 type Prop = {
   created: string;

--- a/src/package.css
+++ b/src/package.css
@@ -302,47 +302,6 @@ jspm-packages-readme img {
   max-width: 100%;
 }
 
-aside h3 {
-  font-family: "Bebas Neue";
-}
-
-jspm-packages-aside {
-  padding: var(--dl-space-space-oneandhalfunits);
-  min-width: 350px;
-  font-size: var(--step--2);
-}
-
-jspm-packages-aside aside > div {
-  display: flex;
-  align-content: center;
-  align-items: center;
-  gap: 15px;
-  flex-wrap: wrap;
-}
-
-jspm-packages-aside aside > div.maintainers ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: flex-start;
-}
-
-jspm-packages-aside aside > div.maintainers ul li a figure {
-  margin: 0;
-}
-
-jspm-packages-aside aside > div.maintainers ul li a figure img {
-  width: 75px;
-}
-
-/* footer > section{
-  border-bottom: 5px solid black;
-  border-top: 5px solid black;
-} */
-
 footer > section > h3 {
   font-family: "Bebas Neue";
   text-align: left;

--- a/src/package.html
+++ b/src/package.html
@@ -8,7 +8,7 @@
   <link rel="shortcut icon" href="/favicon.ico">
   <link rel="stylesheet" href="https://ga.jspm.io/npm:normalize.css@8.0.1/normalize.css" />
   <link rel="stylesheet"
-    href="https://fonts.googleapis.com/css2?family=Abril+Fatface&family=Sen:wght@400;700;800&family=Roboto+Condensed:wght@300&family=DM+Mono&family=Bebas+Neue&family=Major+Mono+Display&family=Playfair+Display:ital,wght@0,400;0,700;0,900;1,700&family=Source+Code+Pro&family=Source+Sans+Pro:wght@700&&family=Vollkorn&family=Inter:wght@200;400;800&display=swap" />
+    href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;700&family=Abril+Fatface&family=Sen:wght@400;700;800&family=Roboto+Condensed:wght@300&family=DM+Mono&family=Bebas+Neue&family=Major+Mono+Display&family=Playfair+Display:ital,wght@0,400;0,700;0,900;1,700&family=Source+Code+Pro&family=Source+Sans+Pro:wght@700&&family=Vollkorn&family=Inter:wght@200;400;800&display=swap" />
   <!-- <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/PrismJS/prism-themes@master/themes/prism-shades-of-purple.css"> -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/PrismJS/prism-themes@master/themes/prism-gruvbox-dark.css">
   <link rel="stylesheet" href="/custom-properties.css" />

--- a/src/package.tsx
+++ b/src/package.tsx
@@ -1,13 +1,12 @@
 /** @jsx h */
 
 import { Fragment, Helmet, h } from "nano-jsx";
-import { Readme } from "@jspm/packages/readme";
-// import { Aside } from "@jspm/packages/aside";
-import { Header } from "@jspm/packages/header";
-import { Hero } from "@jspm/packages/hero";
-import { PackageExports } from "@jspm/packages/package-exports";
+import { Readme } from "#readme";
+import { Header } from "#header";
+import { Hero } from "#hero";
+import { PackageExports } from "#package-exports";
 
-import type { Maintainer, ExportsTarget } from "@jspm/packages/types";
+import type { Maintainer, ExportsTarget } from "#types";
 
 type Prop = {
   createdTime: string;
@@ -167,26 +166,6 @@ function Package({
               </jspm-packages-readme>
             </details>
           </main>
-          {/* <jspm-packages-aside>
-          <Aside
-            created={created}
-            updated={updated}
-            dependencies={dependencies}
-            downloads={downloads}
-            version={version}
-            versions={versions}
-            name={name}
-            license={license}
-            files={files}
-            exports={exports}
-            keywords={keywords}
-            type={type}
-            types={types}
-            features={features}
-            links={links}
-            maintainers={maintainers}
-          />
-        </jspm-packages-aside> */}
         </section>
         <footer>
           <section class="maintainers">

--- a/src/request-handlers.tsx
+++ b/src/request-handlers.tsx
@@ -16,17 +16,17 @@ import {
   MAYBE_README_FILES,
   NPM_PROVIDER_URL,
   PACKAGE_BASE_PATH,
-} from "@jspm/packages/constants";
+} from "#constants";
 import {
   parsePackageNameVersion,
   removeSlashes,
-} from "@jspm/packages/functions";
-import { HomeSSR } from "@jspm/packages/home-ssr";
-import { SearchResultsSSR } from "@jspm/packages/search-results-ssr";
-import type { Results } from "@jspm/packages/search-results";
-import { PackageSSR } from "@jspm/packages/package-ssr";
-import { features } from "@jspm/packages/package-quality-check";
-import { render } from "@jspm/packages/renderer";
+} from "#functions";
+import { HomeSSR } from "#home-ssr";
+import { SearchResultsSSR } from "#search-results-ssr";
+import type { Results } from "#search-results";
+import { PackageSSR } from "#package-ssr";
+import { features } from "#package-quality-check";
+import { render } from "#renderer";
 
 const staticResourcesFile = await Deno.readTextFile(
   "./lib/static-resources.json"

--- a/src/search-dom.tsx
+++ b/src/search-dom.tsx
@@ -4,16 +4,16 @@
 /// <reference types="https://deno.land/x/nano_jsx@v0.0.33/types.d.ts" />
 
 import { h, hydrate, Component } from "nano-jsx";
-import { store } from "@jspm/packages/store";
-import type { ENV, Store } from "@jspm/packages/store";
-import { fromPkgStrToPin, sortArray } from "@jspm/packages/functions";
-import { ImportmapToggleButton } from "@jspm/packages/importmap-toggle-button";
-import type { ImportmapToggleButtonProp } from "@jspm/packages/importmap-toggle-button";
-import { ImportMapDialog } from "@jspm/packages/importmap-dialog";
-import type { ImportMapDialogProp } from "@jspm/packages/importmap-dialog";
-import { GeneratorLink } from "@jspm/packages/generator-link";
-import type { GeneratorLinkProp } from "@jspm/packages/generator-link";
 import { Generator } from "@jspm/generator";
+import { store } from "#store";
+import type { ENV, Store } from "#store";
+import { fromPkgStrToPin, sortArray } from "#functions";
+import { ImportmapToggleButton } from "#importmap-toggle-button";
+import type { ImportmapToggleButtonProp } from "#importmap-toggle-button";
+import { ImportMapDialog } from "#importmap-dialog";
+import type { ImportMapDialogProp } from "#importmap-dialog";
+import { GeneratorLink } from "#generator-link";
+import type { GeneratorLinkProp } from "#generator-link";
 
 function hydrateImportmapToggleButton({
   dependencyCount,
@@ -159,7 +159,7 @@ class DOM extends Component {
   };
 
   generateJSPMGeneratorHash = async (state) => {
-    const { stateToHash } = await import("@jspm/packages/statehash");
+    const { stateToHash } = await import("#statehash");
     const generatorHash = await stateToHash(state);
 
     this.store.setState({

--- a/src/search-results-ssr.tsx
+++ b/src/search-results-ssr.tsx
@@ -1,7 +1,7 @@
 /** @jsx h */
 import { h } from "nano-jsx";
-import { SearchResults } from "@jspm/packages/search-results";
-import type { SearchResultsProp } from "@jspm/packages/search-results";
+import { SearchResults } from "#search-results";
+import type { SearchResultsProp } from "#search-results";
 
 function SearchResultsSSR({
   objects,

--- a/src/search-results.tsx
+++ b/src/search-results.tsx
@@ -1,9 +1,9 @@
 /** @jsx h */
 
 import { h, Fragment } from "nano-jsx";
-import { Header } from "@jspm/packages/header";
-import { SearchResult } from "@jspm/packages/search-result";
-import type { Result } from "@jspm/packages/search-result";
+import { Header } from "#header";
+import { SearchResult } from "#search-result";
+import type { Result } from "#search-result";
 
 type Results = {
   objects: Result[];

--- a/src/search.html
+++ b/src/search.html
@@ -8,7 +8,7 @@
     <link rel="shortcut icon" href="/favicon.ico">
     <link rel="stylesheet" href="https://ga.jspm.io/npm:normalize.css@8.0.1/normalize.css" />
     <link rel="stylesheet"
-        href="https://fonts.googleapis.com/css2?family=Abril+Fatface&family=DM+Mono&family=Bebas+Neue&family=Major+Mono+Display&family=Playfair+Display:ital,wght@0,400;0,700;0,900;1,700&family=Source+Code+Pro&family=Source+Sans+Pro:wght@700&&family=Vollkorn&family=Inter:wght@200;400;800&display=swap" />
+        href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;700&family=Abril+Fatface&family=DM+Mono&family=Bebas+Neue&family=Major+Mono+Display&family=Playfair+Display:ital,wght@0,400;0,700;0,900;1,700&family=Source+Code+Pro&family=Source+Sans+Pro:wght@700&&family=Vollkorn&family=Inter:wght@200;400;800&display=swap" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/PrismJS/prism-themes@master/themes/prism-gruvbox-dark.css">
 
     <link rel="stylesheet" href="/custom-properties.css" />

--- a/src/search.tsx
+++ b/src/search.tsx
@@ -1,6 +1,6 @@
 /** @jsx h */
 import { h } from "nano-jsx";
-import { FEATURED_PACKAGES } from "@jspm/packages/featured-packages-list";
+import { FEATURED_PACKAGES } from "#featured-packages-list";
 
 function Search() {
   return (

--- a/src/ssr-home.tsx
+++ b/src/ssr-home.tsx
@@ -1,7 +1,7 @@
 /** @jsx h */
 import { h } from "nano-jsx";
-import { FEATURED_PACKAGES } from "@jspm/packages/featured-packages-list";
-import { Home } from "@jspm/packages/home";
+import { FEATURED_PACKAGES } from "#featured-packages-list";
+import { Home } from "#home";
 
 function SSRHome() {
   return (

--- a/src/style.css
+++ b/src/style.css
@@ -26,6 +26,7 @@ h4,
 h5,
 h6 {
   font-family: "Roboto", sans-serif;
+  font-family: 'Source Sans Pro', sans-serif;
 }
 h2 {
   font-size: var(--step-3);
@@ -55,6 +56,7 @@ pre[class*="language-"] {
 
 body {
   font-family: "Inter", sans-serif;
+  font-family: 'Source Sans Pro', sans-serif;
   font-size: var(--step--1);
 }
 
@@ -409,6 +411,7 @@ jspm-packages-importmap-dialog dialog .importmap-text:hover .link-copy {
 
 jspm-packages-importmap-dialog dialog header {
   font-family: "Roboto" sans-serif;
+  font-family: 'Source Sans Pro', sans-serif;
   font-size: 16px;
   margin-bottom: var(--dl-space-space-unit);
 }
@@ -439,10 +442,7 @@ jspm-packages-importmap-dialog .jspm-packages-importmap-dialog-links a {
   align-items: center;
   align-content: center;
 }
-/* jspm-packages-importmap-dialog .jspm-packages-importmap-dialog-links a[download]{
-  background: transparent url(/icon-download-black.png) left center no-repeat;
-  padding-left: 20px;
-} */
+
 jspm-packages-importmap-dialog
   .jspm-packages-importmap-dialog-links
   .icon-customization {
@@ -450,24 +450,7 @@ jspm-packages-importmap-dialog
     no-repeat;
   padding-left: 20px;
 }
-jspm-generator-link {
-  font-size: 14px;
-  display: inline-block;
-  margin-bottom: var(--dl-space-space-unit);
-}
 
-jspm-packages-importmap-dialog dialog jspm-generator-link a {
-  display: inline-block;
-  background: url(/images/icon-external-link.png) no-repeat right center;
-  background-size: contain;
-  padding-right: var(--dl-space-space-twounits);
-}
-
-/* jspm-packages-importmap-dialog dialog details {
-  margin: var(--dl-space-space-halfunit) 0px;
-  border-radius: 8px;
-  border: 1px solid #ccc;
-} */
 
 jspm-packages-importmap-dialog dialog details summary,
 jspm-importmap-entry-summary {


### PR DESCRIPTION
Motivation is to express only external routes as [package `exports` field](https://nodejs.org/api/packages.html#package-entry-points). 
External routes are request handlers for server side and transpiled / optimised files for browser.
All internal imports will use [package `imports` field](https://nodejs.org/api/packages.html#imports).

