### PR TITLE
use cachefly as default provider

### DIFF
--- a/chompfile.toml
+++ b/chompfile.toml
@@ -71,7 +71,8 @@ run = '''
 
     const generator = new Generator({
       mapUrl: import.meta.url,
-      env: ["deno", "production"],
+      env: ["deno", "production"], 
+      defaultProvider: 'jspm.cachefly',
       inputMap: {
         imports: {
           "nano-jsx": "https://deno.land/x/nano_jsx@v0.0.33/mod.ts"
@@ -98,7 +99,8 @@ run = '''
 
     const generator = new Generator({
       mapUrl: pathToFileURL(process.env.TARGET),
-      env: ["browser", "production"],
+      env: ["browser", "production"], 
+      defaultProvider: 'jspm.cachefly'
     });
 
     const htmlSource = await readFile(process.env.DEP, 'utf-8');


### PR DESCRIPTION
- https://github.com/jspm/generator/pull/174

## cachefly doesn't serve HTTP3
### [cachefly](https://jspm-packages-xsw6xf36mf50.deno.dev/) 
<img width="739" alt="Screenshot 2022-10-01 at 14 43 33" src="https://user-images.githubusercontent.com/450624/193410396-984f6593-4531-4ce2-9ac2-a3a75e21d0f7.png">

### [ga.jspm.io](https://jspm-packages.deno.dev/)
<img width="901" alt="Screenshot 2022-10-01 at 14 44 07" src="https://user-images.githubusercontent.com/450624/193410399-32b886ef-f717-4daa-ba5c-55d308db4d00.png">

## Some dependencies still point to ga.jspm.io somehow but with HTTP2

### [cachefly](https://jspm-packages-xsw6xf36mf50.deno.dev/) 
<img width="720" alt="Screenshot 2022-10-01 at 14 46 36" src="https://user-images.githubusercontent.com/450624/193410400-02f543c2-dfb2-4074-b809-4e1d46d1de35.png">

### [ga.jspm.io](https://jspm-packages.deno.dev/)
<img width="729" alt="Screenshot 2022-10-01 at 14 46 58" src="https://user-images.githubusercontent.com/450624/193410401-6cff6e29-80c0-450d-a1a1-9364af892434.png">


